### PR TITLE
✨ feat: preserve inline custom title on canonical alert form

### DIFF
--- a/mdformat_gfm_alerts/mdit_plugins/_gfm_alerts.py
+++ b/mdformat_gfm_alerts/mdit_plugins/_gfm_alerts.py
@@ -49,13 +49,15 @@ class AlertRuleFactory:
     ) -> list[re.Pattern[str]]:
         marker_name_re = "\\w+" if self.titles == ["*"] else "|".join(self.titles)
         flags = 0 if self.match_case_sensitive else re.IGNORECASE
+        # Bound the inline-title capture to a single line; the previous `[^\\n\\r]*` was a raw-string trap that
+        # excluded `\`, `n`, `r` instead of newlines and leaked body text across line breaks.
         return [
             re.compile(
-                r"^(?P<marker>\*\*(?P<title>(Note|Warning))\*\*:?)\s*(?P<inline>[^\\n\\r]*)?",
+                r"^(?P<marker>\*\*(?P<title>(Note|Warning))\*\*:?)[ \t]*(?P<inline>[^\n\r]*)",
                 flags=flags,
             ),
             re.compile(
-                rf"^(?P<marker>\\?\[!(?P<title>({marker_name_re}))\\?\])\s*(?P<inline>[^\\n\\r]*)?",
+                rf"^(?P<marker>\\?\[!(?P<title>({marker_name_re}))\\?\])[ \t]*(?P<inline>[^\n\r]*)",
                 flags=flags,
             ),
         ]
@@ -67,29 +69,47 @@ class AlertRuleFactory:
             None,
         )
 
+    @staticmethod
+    def _get_first_inline_index(tokens: list[Token], start: int, end: int) -> int:
+        for index in range(start, end + 1):
+            if tokens[index].type == "inline":
+                return index
+        return -1
+
     def _block_to_alerts_if_matched(
         self,
         tokens: list[Token],
         start_index: int,
         end_index: int,
-    ) -> None:
+    ) -> int:
         first_inline = self._get_first_inline(tokens, start_index, end_index)
         if not first_inline:
-            return
+            return 0
 
-        match = self.patterns[0].match(first_inline.content) or self.patterns[1].match(
-            first_inline.content,
-        )
+        match_index = -1
+        match = None
+        for pattern_index, pattern in enumerate(self.patterns):
+            match = pattern.match(first_inline.content)
+            if match:
+                match_index = pattern_index
+                break
 
         if not match:
-            return
+            return 0
 
         title = match.group("title").strip()
         icon = self.icons.get(title.lower(), "")
 
-        first_inline.content = first_inline.content[
-            len(match.group("marker")) :
-        ].lstrip()
+        # Hugo and Obsidian treat trailing text on the canonical `[!TYPE]` line as a custom title; the alternate
+        # syntaxes never carried that meaning so keep them on the pre-existing normalize-into-body path.
+        is_canonical_unescaped = match_index == 1 and "\\" not in match.group("marker")
+        inline = match.group("inline") or ""
+        if is_canonical_unescaped:
+            inline_title = inline.strip()
+            first_inline.content = first_inline.content[match.end() :].lstrip()
+        else:
+            inline_title = ""
+            first_inline.content = first_inline.content[len(match.group("marker")) :].lstrip()
 
         open_token = tokens[start_index]
         close_token = tokens[end_index]
@@ -99,10 +119,25 @@ class AlertRuleFactory:
         open_token.meta = {
             "title": title,
             "icon": icon,
+            "inline_title": inline_title,
         }
 
         close_token.type = GFM_ALERT_CLOSE
         close_token.tag = "div"
+
+        # An empty leading paragraph would render as a stray `<p></p>` next to the title; drop it so downstream
+        # renderers don't have to filter empty paragraphs out of every alert.
+        if is_canonical_unescaped and not first_inline.content:
+            inline_index = self._get_first_inline_index(tokens, start_index, end_index)
+            if (
+                inline_index > 0
+                and tokens[inline_index - 1].type == "paragraph_open"
+                and inline_index + 1 <= end_index
+                and tokens[inline_index + 1].type == "paragraph_close"
+            ):
+                del tokens[inline_index - 1 : inline_index + 2]
+                return 3
+        return 0
 
     def get_rule(self) -> Callable[[StateCore], None]:
         def github_alerts_rule(state: StateCore) -> None:
@@ -115,11 +150,13 @@ class AlertRuleFactory:
                 elif tokens[i].type == "blockquote_close":
                     start_index = start_indices.pop()
                     if self.parse_nested or not start_indices:
-                        self._block_to_alerts_if_matched(
+                        removed = self._block_to_alerts_if_matched(
                             tokens,
                             start_index,
                             end_index=i,
                         )
+                        # Rewind past any deletions so the outer cursor stays aligned with the token list.
+                        i -= removed
                 i += 1
 
         return github_alerts_rule
@@ -144,6 +181,8 @@ def gfm_alerts_plugin(
 
     md.core.ruler.after("block", GFM_ALERTS_PREFIX, github_alerts_rule)
 
+    inline_md = MarkdownIt()
+
     def render_alert_open(
         self: RendererProtocol,  # noqa: ARG001
         tokens: list[Token],
@@ -152,10 +191,15 @@ def gfm_alerts_plugin(
         env,  # noqa: ANN001,ARG001
     ) -> str:
         meta = tokens[idx].meta
+        inline_title = meta.get("inline_title", "")
+        if inline_title:
+            title_html = inline_md.renderInline(inline_title)
+        else:
+            title_html = meta["title"].title()
         return (
             f'<div class="{class_prefix} {class_prefix}-{meta["title"].lower()}">\n'
             f'<p class="{class_prefix}-title">'
-            f"{meta['icon']}{meta['title'].title()}</p>\n"
+            f"{meta['icon']}{title_html}</p>\n"
         )
 
     def render_alert_close(

--- a/mdformat_gfm_alerts/plugin.py
+++ b/mdformat_gfm_alerts/plugin.py
@@ -23,6 +23,10 @@ def _render_alert(node: RenderTreeNode, context: RenderContext) -> str:
 
         result = f"> [!{open_token.meta['title'].upper()}]"
 
+        inline_title = open_token.meta.get("inline_title", "")
+        if inline_title:
+            result += f" {inline_title}"
+
         open_token.type = "blockquote_open"
         open_token.tag = "blockquote"
         open_token.meta = {}

--- a/tests/format/fixtures/gfm_alerts.md
+++ b/tests/format/fixtures/gfm_alerts.md
@@ -93,3 +93,66 @@ Don't crash on incomplete alert (https://github.com/KyleKing/mdformat-obsidian/i
 .
 > [!NOTE]
 .
+
+Preserves an inline custom title on the canonical `[!TYPE]` form (Hugo/Obsidian extension)
+.
+> [!TIP] **When to use it:**
+>
+> - One bullet.
+> - Another bullet.
+
+> [!NOTE] Inline title with a colon:
+>
+> Body paragraph.
+
+> [!WARNING] Plain inline text
+>
+> Body paragraph.
+.
+> [!TIP] **When to use it:**
+> - One bullet.
+> - Another bullet.
+
+> [!NOTE] Inline title with a colon:
+> Body paragraph.
+
+> [!WARNING] Plain inline text
+> Body paragraph.
+.
+
+Inline title with no body is emitted on the marker line
+.
+> [!TIP] **Standalone title:**
+.
+> [!TIP] **Standalone title:**
+.
+
+Inline title roundtrips through whitespace variations
+.
+> [!TIP]   **Spaced title:**
+> Body.
+.
+> [!TIP] **Spaced title:**
+> Body.
+.
+
+Alternate `**Note**` syntax still normalizes inline text into the body
+.
+> **Note**: A note line.
+
+> **Warning**: A warning line.
+.
+> [!NOTE]
+> A note line.
+
+> [!WARNING]
+> A warning line.
+.
+
+Escaped brackets still normalize inline text into the body
+.
+> \[!NOTE\] Useful information that users should know.
+.
+> [!NOTE]
+> Useful information that users should know.
+.

--- a/tests/render/fixtures/gfm_alerts.md
+++ b/tests/render/fixtures/gfm_alerts.md
@@ -29,3 +29,24 @@ Test inline syntax
 <p>This is an inline &quot;Note&quot;</p>
 </div>
 .
+
+Canonical unescaped `[!TYPE]` with inline custom title renders the title in place of the type name
+.
+> [!TIP] **When to use it:**
+>
+> Body paragraph.
+.
+<div class="markdown-alert markdown-alert-tip">
+<p class="markdown-alert-title"><strong>When to use it:</strong></p>
+<p>Body paragraph.</p>
+</div>
+.
+
+Canonical inline title without body
+.
+> [!NOTE] Custom title:
+.
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Custom title:</p>
+</div>
+.


### PR DESCRIPTION
Hugo's goldmark and Obsidian extend the GFM alert syntax to recognize text on the same line as the type marker as a custom title, so an author writing `> [!TIP] **When to use it:**` expects a callout titled `When to use it:` rather than one titled `Tip`. ✨ Running the formatter against that source today moves the trailing text onto its own line, the next render shows the icon next to `Tip` with the bold heading sitting in the body, and the author's intent is lost. The break is silent because no warning fires and the document still parses, which makes it hard to track down once a downstream theme stops rendering the title.

The parser captures any text on the same line as the marker into `meta["inline_title"]`, and the serializer emits it next to the marker on output. Only the canonical, unescaped `[!TYPE]` form opts into preservation: alternate forms like `> **Note**: body` and escaped brackets like `> \[!Note\] body` keep their existing behavior of rewriting to canonical `[!TYPE]\n> body` with the inline text moved into the body, so the "normalize alternate syntax" intent of the existing fixtures stays intact. When the inline title leaves the first paragraph empty, the surrounding `paragraph_open`/`inline`/`paragraph_close` trio is dropped from the token stream so HTML output does not gain a stray `<p></p>`. The HTML renderer routes the inline title through `MarkdownIt.renderInline` so formatting like `**bold**` survives.

A small regex fix rides along. The existing inline capture used `[^\\n\\r]` which, inside a raw string, excludes the literal characters `\`, `n`, `r` rather than line terminators, and pulled body text across line boundaries into the inline group. The replacement `[^\n\r]` matches newline and carriage return.

The format-pass output changes for canonical alerts that carry inline text: the inline text is preserved on the marker line rather than moved to the body. 📝 The HTML output for those alerts also changes since the alert title `<p>` now contains the inline text instead of the type name. Alerts without an inline title render identically to before, and alternate syntaxes still normalize the way they always did. Verified green on my fork against the full CI matrix (pre-commit, pre-commit-hook, py3.9 and py3.12 on Ubuntu and Windows): https://github.com/gaborbernat/mdformat-gfm-alerts/actions/runs/26618040526. Happy to gate the new behavior behind a plugin option if you would rather not ship it on by default.